### PR TITLE
make the value of upstream_contacts calculate correctly

### DIFF
--- a/lua/ngx_metric/ngx_metric.lua
+++ b/lua/ngx_metric/ngx_metric.lua
@@ -73,7 +73,7 @@ function _M.upstream_time(self)
     local resp_time_arr = util.str_split(upstream_response_time_s, ",")
 
     local metric = self:req_sign("upstream_contacts")
-    counter.add(self.dict, metric, #(resp_time_arr) - 1)
+    counter.add(self.dict, metric, #(resp_time_arr))
 
     local duration = 0.0
     for _, t in pairs(resp_time_arr) do


### PR DESCRIPTION
#### 
I understand that upstream_contacts means the count of  contacts upstream server. I found that upstream_contacts is always 0, so I modified it.